### PR TITLE
README: demonstrate a weekly flake.lock update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ name: update-flake-lock
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 0 * * *' # runs daily at 00:00
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
 
 jobs:
   lockfile:


### PR DESCRIPTION
It's arguably not that useful to be inundated with flake.lock update PRs
every day, so do it once a week on Sunday.

---

Closes https://github.com/DeterminateSystems/update-flake-lock/issues/10.