### PR TITLE
Allow consumers to update specific flake inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+      - name: Shellcheck
+        run: nix-shell --run 'shellcheck $(find . -type f -name "*.sh" -executable)'

--- a/README.md
+++ b/README.md
@@ -30,6 +30,36 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@v3
 ```
 
+## Example updating specific input(s)
+
+> **NOTE**: If any inputs have a stale reference (e.g. the lockfile thinks a git input wants its "ref" to be "nixos-unstable", but the flake.nix specifies "nixos-unstable-small"), they will also be updated. At this time, there is no known workaround.
+
+It is also possible to update specific inputs by specifying them in a space-separated list:
+
+```yaml
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@vX
+        with:
+          inputs: input1 input2 input3
+```
+
 ## Running GitHub Actions CI
 
 GitHub Actions will not run workflows when a branch is pushed by or a PR is opened by a GitHub Action. To work around this, try:

--- a/README.md
+++ b/README.md
@@ -22,12 +22,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v14
+        uses: cachix/install-nix-action@v16
         with:
-          install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-          install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
           extra_nix_config: |
-            experimental-features = nix-command flakes
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v3

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,14 @@
 name: 'Update flake.lock'
 description: 'Update your flake.lock and send a PR'
+inputs:
+  inputs:
+    description: 'A space-separated list of inputs to update. Leave empty to update all inputs.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - run: nix flake update --commit-lock-file
+    - run: ./update-input-or-inputs.sh ${{ inputs.inputs }}
       shell: bash
       env:
         GIT_AUTHOR_NAME: github-actions[bot]

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1638263381,
+        "narHash": "sha256-1rZDxTw74ETuJEjwPfpMgY0sfx8Cv1tRNt3gibol574=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7b031d0d99e8cdaf0b70457c0cb33f16c0c958bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "update-flake-lock";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self
+    , nixpkgs
+    }:
+    let
+      nameValuePair = name: value: { inherit name value; };
+      genAttrs = names: f: builtins.listToAttrs (map (n: nameValuePair n (f n)) names);
+
+      allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: genAttrs allSystems
+        (system: f {
+          inherit system;
+          pkgs = import nixpkgs { inherit system; };
+        });
+    in
+    {
+      devShell = forAllSystems
+        ({ system, pkgs, ... }:
+          pkgs.stdenv.mkDerivation {
+            name = "update-flake-lock-devshell";
+            buildInputs = [ pkgs.shellcheck ];
+            src = self;
+          });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+(import
+  (fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+  })
+  { src = ./.; }).shellNix

--- a/update-input-or-inputs.sh
+++ b/update-input-or-inputs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+to_update=$*
+
+if [ -n "$to_update" ]; then
+  inputs=()
+  for input in $to_update; do
+    inputs+=("--update-input" "$input")
+  done
+  nix flake lock "${inputs[@]}" --commit-lock-file
+else
+  nix flake update --commit-lock-file
+fi


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/update-flake-lock/issues/14.

##### Checklist

- [x] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [x] Added or updated relevant documentation (leave unchecked if not applicable)

---

One issue(?) with this is that, if you have e.g. a git input with a stale ref (the lock file thinks it wants "nixos-unstable", but the input actually wants "nixos-unstable-small"), *this will be updated*. As long as all the "ref" stays in tact, it's likely that this will function as expected.