### PR TITLE
README: organize "Running GitHub Actions CI" instructions into own section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v3
+        uses: DeterminateSystems/update-flake-lock@vX
 ```
 
 ## Example updating specific input(s)
@@ -60,16 +60,26 @@ jobs:
           inputs: input1 input2 input3
 ```
 
-## Example github action tests in created PRs
+## Running GitHub Actions CI
 
-By default, this action uses an api token provided by github ci to create the
-pull request. By default, Github does not run github actions, i.e. tests, for
-these types of pull requests. However, you can bypass this restriction by
-specifying a personal authentication token (PAT). You can create a token by
-visiting [https://github.com/settings/tokens]() and select at least the scope
-`repo`. Then store this token in your repository secrets (i.e.
-'https://github.com/<USER>/<REPO>/settings/secrets/actions') as
-`GH_TOKEN_FOR_UPDATES`.
+GitHub Actions will not run workflows when a branch is pushed by or a PR is opened by a GitHub Action. There are two ways to have GitHub Actions CI run on a PR submitted by this action.
+
+### Without a Personal Authentication Token
+
+Without using a Personal Authentication Token, you can manually run the following to kick off a CI run:
+
+```
+git branch -D update_flake_lock_action
+git fetch origin
+git checkout update_flake_lock_action
+git commit --amend --no-edit
+git push origin update_flake_lock_action --force
+```
+
+### With a Personal Authentication Token
+
+By providing a Personal Authentication Token, the PR will be submitted in a way that bypasses this limitation (GitHub will essentially think it is the owner of the PAT submitting the PR, and not an Action).
+You can create a token by visiting https://github.com/settings/tokens and select at least the `repo` scope. Then, store this token in your repository secrets (i.e. 'https://github.com/<USER>/<REPO>/settings/secrets/actions') as `GH_TOKEN_FOR_UPDATES` and set up your workflow file like the following:
 
 ```yaml
 name: update-flake-lock
@@ -90,18 +100,6 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@vX
         with:
           token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
-```
-
-## Running GitHub Actions CI
-
-GitHub Actions will not run workflows when a branch is pushed by or a PR is opened by a GitHub Action. To work around this, try:
-
-```
-git branch -D update_flake_lock_action
-git fetch origin
-git checkout update_flake_lock_action
-git commit --amend --no-edit
-git push origin update_flake_lock_action --force
 ```
 
 ## Contributing


### PR DESCRIPTION
##### Description

There were two sections for ways to get Actions to run on a submitted PR, so I restructured them to be children of the same header.

##### Checklist

- [ ] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
