### PR TITLE
feat: allow specifying a path to flake.nix within the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@vX
         with:
           inputs: input1 input2 input3
+          path-to-flake-dir: 'nix/' # in this example our flake doesn't sit at the root of the repository, it sits under 'nix/flake.nix'
 ```
 
 ## Running GitHub Actions CI

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'The branch of the PR to be created'
     required: false
     default: "update_flake_lock_action"
+  path-to-flake-dir:
+    description: 'The path of the directory containing `flake.nix` file within your repository. Useful when `flake.nix` cannot reside at the root of your repository.'
+    required: false
+    default: ''
   pr-title:
     description: 'The title of the PR to be created'
     required: false
@@ -114,6 +118,7 @@ runs:
         GIT_COMMITTER_EMAIL: ${{ env.GIT_COMMITTER_EMAIL }}
         TARGETS: ${{ inputs.inputs }}
         COMMIT_MSG: ${{ inputs.commit-msg }}
+        PATH_TO_FLAKE_DIR: ${{ inputs.path-to-flake-dir }}
     - name: Save PR Body as file
       uses: DamianReeves/write-file-action@v1.1
       with:

--- a/update-flake-lock.sh
+++ b/update-flake-lock.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -n "$PATH_TO_FLAKE_DIR" ]]; then
+  cd "$PATH_TO_FLAKE_DIR"
+fi
+
 if [[ -n "$TARGETS" ]]; then
     inputs=()
     for input in $TARGETS; do


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

Allow specifying a path to flake.nix within the repository - resolves #50. I ran a single test where I used the `path-to-flake-nix` input and it performed as expected.

##### Checklist

- [x] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
