### PR TITLE
Allow to customize git author/committer name+email

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,37 @@ jobs:
           path-to-flake-dir: 'nix/' # in this example our flake doesn't sit at the root of the repository, it sits under 'nix/flake.nix'
 ```
 
+## Example using a different Git user
+
+If you want to change the author and / or committer of the flake.lock update commit, you can tweak the `git-{author,committer}-{name,email}` options:
+
+```yaml
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@vX
+        with:
+          git-author-name: 'Jane Author'
+          git-author-email: 'github-actions[bot]@users.noreply.github.com'
+          git-committer-name: 'John Committer'
+          git-committer-email: 'github-actions[bot]@users.noreply.github.com'
+```
+
 ## Running GitHub Actions CI
 
 GitHub Actions will not run workflows when a branch is pushed by or a PR is opened by a GitHub Action. There are two ways to have GitHub Actions CI run on a PR submitted by this action.

--- a/action.yml
+++ b/action.yml
@@ -121,9 +121,9 @@ runs:
       shell: bash
       run: |
         echo "GIT_AUTHOR_NAME=${{ inputs.git-author-name }}" >> $GITHUB_ENV
-        echo "GIT_AUTHOR_EMAIL=${{ inputs.git-author-email }}" >> $GITHUB_ENV
+        echo "GIT_AUTHOR_EMAIL=<${{ inputs.git-author-email }}>" >> $GITHUB_ENV
         echo "GIT_COMMITTER_NAME=${{ inputs.git-committer-name }}" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_EMAIL=${{ inputs.git-committer-email }}" >> $GITHUB_ENV
+        echo "GIT_COMMITTER_EMAIL=<${{ inputs.git-committer-email }}>" >> $GITHUB_ENV
     - name: Run update-flake-lock.sh
       run: $GITHUB_ACTION_PATH/update-flake-lock.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,22 @@ inputs:
     description: 'A comma or newline separated list of labels to set on the Pull Request to be created'
     required: false
     default: ''
+  git-author-name:
+    description: 'Author name used for commit. Only used if sign-commits is false.'
+    required: false
+    default: 'github-actions[bot]'
+  git-author-email:
+    description: 'Author email used for commit. Only used if sign-commits is false.'
+    required: false
+    default: 'github-actions[bot]@users.noreply.github.com>'
+  git-committer-name:
+    description: 'Committer name used for commit. Only used if sign-commits is false.'
+    required: false
+    default: 'github-actions[bot]'
+  git-committer-email:
+    description: 'Committer email used for commit. Only used if sign-commits is false.'
+    required: false
+    default: 'github-actions[bot]@users.noreply.github.com>'
   sign-commits:
     description: 'Set to true if the action should sign the commit with GPG'
     required: false
@@ -104,10 +120,10 @@ runs:
       if: ${{ inputs.sign-commits != 'true' }}
       shell: bash
       run: |
-        echo "GIT_AUTHOR_NAME=github-actions[bot]" >> $GITHUB_ENV
-        echo "GIT_AUTHOR_EMAIL=<github-actions[bot]@users.noreply.github.com>" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_NAME=github-actions[bot]" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_EMAIL=<github-actions[bot]@users.noreply.github.com>" >> $GITHUB_ENV
+        echo "GIT_AUTHOR_NAME=${{ inputs.git-author-name }}" >> $GITHUB_ENV
+        echo "GIT_AUTHOR_EMAIL=${{ inputs.git-author-email }}" >> $GITHUB_ENV
+        echo "GIT_COMMITTER_NAME=${{ inputs.git-committer-name }}" >> $GITHUB_ENV
+        echo "GIT_COMMITTER_EMAIL=${{ inputs.git-committer-email }}" >> $GITHUB_ENV
     - name: Run update-flake-lock.sh
       run: $GITHUB_ACTION_PATH/update-flake-lock.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
   git-author-email:
     description: 'Author email used for commit. Only used if sign-commits is false.'
     required: false
-    default: 'github-actions[bot]@users.noreply.github.com>'
+    default: 'github-actions[bot]@users.noreply.github.com'
   git-committer-name:
     description: 'Committer name used for commit. Only used if sign-commits is false.'
     required: false
@@ -68,7 +68,7 @@ inputs:
   git-committer-email:
     description: 'Committer email used for commit. Only used if sign-commits is false.'
     required: false
-    default: 'github-actions[bot]@users.noreply.github.com>'
+    default: 'github-actions[bot]@users.noreply.github.com'
   sign-commits:
     description: 'Set to true if the action should sign the commit with GPG'
     required: false


### PR DESCRIPTION
##### Description

This PR adds additional non-required inputs that allow to customize the name and email used for the commit author and committer.

##### Checklist

- [ ] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
