### PR TITLE
feat: accept list of reviewers and assignees

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,33 @@ However you can customize it, with variable interpolation performed with [Handle
 - env.GIT_COMMITTER_EMAIL
 - env.GIT_COMMIT_MESSAGE
 
+## Add assignees or reviewers
+
+You can assign the PR to or request a review from one or more GitHub users with `pr-assignees` and `pr-reviewers`, respectively.
+These properties expect a comma or newline separated list of GitHub usernames:
+
+```yaml
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 1,4' # Run twice a week
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@vX
+        with:
+          pr-assignees: SomeGitHubUsername
+          pr-reviewers: SomeOtherGitHubUsername,SomeThirdGitHubUsername
+```
+
 ## Contributing
 
 Feel free to send a PR or open an issue if you find something functions unexpectedly! Please make sure to test your changes and update any related documentation before submitting your PR.

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,14 @@ inputs:
     description: 'A comma or newline separated list of labels to set on the Pull Request to be created'
     required: false
     default: ''
+  pr-assignees:
+    description: 'A comma or newline separated list of assignees (GitHub usernames).'
+    required: false
+    default: ''
+  pr-reviewers:
+    description: 'A comma or newline separated list of reviewers (GitHub usernames) to request a review from.'
+    required: false
+    default: ''
   git-author-name:
     description: 'Author name used for commit. Only used if sign-commits is false.'
     required: false
@@ -176,5 +184,7 @@ runs:
         author: ${{ env.GIT_AUTHOR_NAME }} ${{ env.GIT_AUTHOR_EMAIL }}
         title: ${{ inputs.pr-title }}
         token: ${{ inputs.token }}
+        assignees: ${{ inputs.pr-assignees }}
         labels: ${{ inputs.pr-labels }}
+        reviewers: ${{ inputs.pr-reviewers }}
         body: ${{ steps.pr_body.outputs.contents }}


### PR DESCRIPTION
Pass a list of GitHub usernames through to
peter-evans/create-pull-request.

Assignees are specified with the `pr-assignees` property.
Reviewers are specified with the `pr-reviewers` property.

Both properties expect the value to be a list of GitHub usernames,
separated by either commas or newlines.

## Testing

- https://github.com/EricCrosson/test-update-flake-lock/pull/1
  This PR tested the new code without specifying either of `pr-reviewers` or `pr-assignees`. As expected, there are no reviewers or assignees.
- https://github.com/EricCrosson/test-update-flake-lock/pull/2
  This PR tested the new code, specifying both `pr-reviewers` and `pr-assignees`. As expected, the reviewer and assignee was added to the PR. There were no error messages in the logs of the GitHub Actions execution.