### PR TITLE
fix(deps): upgrade DamianReeves/write-file-action to v1.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,7 +144,7 @@ runs:
         COMMIT_MSG: ${{ inputs.commit-msg }}
         PATH_TO_FLAKE_DIR: ${{ inputs.path-to-flake-dir }}
     - name: Save PR Body as file
-      uses: DamianReeves/write-file-action@v1.1
+      uses: DamianReeves/write-file-action@v1.2
       with:
         path: pr_body.template
         contents: ${{ inputs.pr-body }}


### PR DESCRIPTION
https://github.com/DamianReeves/write-file-action/releases/tag/v1.2

This bumps the write-file-action from the Node.js 12 runtime to Node.js
16, avoiding a warning that Node.js 12 actions are deprecated[^1].

[^1]: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/