### PR TITLE
New `custom-logic` action input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,10 @@ inputs:
     description: 'GPG Private Key Passphrase for the GPG Private Key with which to sign the commits in the PR to be created'
     required: false
     default: ''
+  custom-logic:
+    description: 'Custom shell commands to execute just before the PR creation (after the commit creation)'
+    required: false
+    default: ''
 outputs:
   pull-request-number:
     description: 'The number of the opened pull request'
@@ -158,6 +162,10 @@ runs:
         GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\r'/'%0D'}"
         echo "GIT_COMMIT_MESSAGE=$GIT_COMMIT_MESSAGE" >> $GITHUB_ENV
         echo "GIT_COMMIT_MESSAGE is: ${GIT_COMMIT_MESSAGE}"
+    - name: Set additional env variables (custom logic)
+      shell: bash
+      if: ${{ inputs.custom-logic != '' }}
+      run: ${{ inputs.custom-logic }}
     - name: Interpolate PR Body
       uses: pedrolamas/handlebars-action@v2.2.0
       with:


### PR DESCRIPTION
##### Description

I've added a new option `custom-logic` that allows executing custom logic *after* that `update-flake-lock.sh` is executed but *before* that the PR body is interpolated. The use case that justified this is that I wanted to put the output of `nix store diff-closures` inside the PR body. But I couldn't do this before the entire `update-flake-lock` action since I needed to run it after that the lockfile was updated.

```
 - name: Update flake.lock
    uses: aciceri/update-flake-lock@main
    with:
      custom-logic: |
        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
        echo "DIFF_CLOSURES<<$EOF" >> $GITHUB_ENV
        nix run .#diff-closures >> $GITHUB_ENV
        echo "$EOF" >> $GITHUB_ENV
      pr-title: "Automatic `flake.lock` update"
      pr-body: |
        # Automatic update
        ## Inputs updated
        ```
          {{ env.GIT_COMMIT_MESSAGE }}
        ```
        ## Closures diff
        ```
        {{ env.DIFF_CLOSURES }}
        ```
```

![image](https://user-images.githubusercontent.com/2318843/224189023-13c5dc53-66c9-41b3-9587-7b4645f5ea8f.png)


Frankly I don't know if you want this, perhaps it's just an useless complication that will be useful for a small portion of people. Meanwhile I leave it here as a draft PR and only if you like it I'll add some lines in the README

##### Checklist

- [x] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes)) **Not the template one but [this](https://github.com/aciceri/emacs)**
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
