### PR TITLE
expose status of PR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -96,6 +96,9 @@ outputs:
   pull-request-number:
     description: 'The number of the opened pull request'
     value: ${{ steps.create-pr.outputs.pull-request-number }}
+  pull-request-operation:
+    description: 'The pull request operation performed by the action, `created`, `updated` or `closed`.'
+    value: ${{ steps.create-pr.outputs.pull-request-operation }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->
I want to use an `automerge` GHA like this: https://github.com/peter-evans/enable-pull-request-automerge#create-pull-request-example
I think this is reasonable to have status of the PR created by this action being outputted? 

##### Checklist

- [x] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
