### PR TITLE
Feat/add nix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,31 @@ jobs:
           inputs: input1 input2 input3
 ```
 
+## Example adding options to nix command
+
+It is also possible to use specific options to the nix command
+
+```yaml
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v1
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@vX
+        with:
+          nix-options: --debug
+```
+
 ## Example that prints the number of the created PR
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ jobs:
 
 ## Example adding options to nix command
 
-It is also possible to use specific options to the nix command
+It is also possible to use specific options to the nix command in a space separated list:
 
 ```yaml
 name: update-flake-lock
@@ -81,7 +81,7 @@ jobs:
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@vX
         with:
-          nix-options: --debug
+          nix-options: --debug --log-format raw
 ```
 
 ## Example that prints the number of the created PR

--- a/action.yml
+++ b/action.yml
@@ -199,4 +199,4 @@ runs:
         assignees: ${{ inputs.pr-assignees }}
         labels: ${{ inputs.pr-labels }}
         reviewers: ${{ inputs.pr-reviewers }}
-        body: ${{ steps.pr_body.outputs.contents }}
+        body: ${{ steps.pr_body.outputs.content }}

--- a/action.yml
+++ b/action.yml
@@ -163,12 +163,15 @@ runs:
     - name: Set additional env variables (GIT_COMMIT_MESSAGE)
       shell: bash
       run: |
-        GIT_COMMIT_MESSAGE="$(git log --format=%b -n 1)"
-        GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//'%'/'%25'}"
-        GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\n'/'%0A'}"
-        GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\r'/'%0D'}"
-        echo "GIT_COMMIT_MESSAGE=$GIT_COMMIT_MESSAGE" >> $GITHUB_ENV
-        echo "GIT_COMMIT_MESSAGE is: ${GIT_COMMIT_MESSAGE}"
+        DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        COMMIT_MESSAGE="$(git log --format=%b -n 1)"
+        # GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//'%'/'%25'}"
+        # GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\n'/'%0A'}"
+        # GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\r'/'%0D'}"
+        echo "GIT_COMMIT_MESSAGE<<$DELIMITER" >> $GITHUB_ENV
+        echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
+        echo "$DELIMITER" >> $GITHUB_ENV
+        echo "GIT_COMMIT_MESSAGE is: ${COMMIT_MESSAGE}"
     - name: Interpolate PR Body
       uses: pedrolamas/handlebars-action@v2.2.0
       with:

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
         output-filename: 'pr_body.txt'
     - name: Read pr_body.txt
       id: pr_body
-      uses: andstor/file-reader-action@v1
+      uses: juliangruber/read-file-action@v1
       with:
         path: "pr_body.txt"
     # We need to remove the pr_body files so that the

--- a/action.yml
+++ b/action.yml
@@ -95,6 +95,10 @@ inputs:
     description: 'GPG Private Key Passphrase for the GPG Private Key with which to sign the commits in the PR to be created'
     required: false
     default: ''
+  nix-options:
+    description: 'A space-separated list of options to pass to the nix command'
+    required: false
+    default: ''
 outputs:
   pull-request-number:
     description: 'The number of the opened pull request'
@@ -146,6 +150,7 @@ runs:
         GIT_AUTHOR_EMAIL: ${{ env.GIT_AUTHOR_EMAIL }}
         GIT_COMMITTER_NAME: ${{ env.GIT_COMMITTER_NAME }}
         GIT_COMMITTER_EMAIL: ${{ env.GIT_COMMITTER_EMAIL }}
+        NIX_OPTIONS: ${{ inputs.nix-options }}
         TARGETS: ${{ inputs.inputs }}
         COMMIT_MSG: ${{ inputs.commit-msg }}
         PATH_TO_FLAKE_DIR: ${{ inputs.path-to-flake-dir }}

--- a/action.yml
+++ b/action.yml
@@ -165,9 +165,6 @@ runs:
       run: |
         DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         COMMIT_MESSAGE="$(git log --format=%b -n 1)"
-        # GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//'%'/'%25'}"
-        # GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\n'/'%0A'}"
-        # GIT_COMMIT_MESSAGE="${GIT_COMMIT_MESSAGE//$'\r'/'%0D'}"
         echo "GIT_COMMIT_MESSAGE<<$DELIMITER" >> $GITHUB_ENV
         echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
         echo "$DELIMITER" >> $GITHUB_ENV

--- a/update-flake-lock.sh
+++ b/update-flake-lock.sh
@@ -5,12 +5,19 @@ if [[ -n "$PATH_TO_FLAKE_DIR" ]]; then
   cd "$PATH_TO_FLAKE_DIR"
 fi
 
+options=()
+if [[ -n "$NIX_OPTIONS" ]]; then
+    for option in $NIX_OPTIONS; do
+        options+=("${option}")
+    done
+fi
+
 if [[ -n "$TARGETS" ]]; then
     inputs=()
     for input in $TARGETS; do
         inputs+=("--update-input" "$input")
     done
-    nix flake lock "${inputs[@]}" --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
+    nix "${options[@]}" flake lock "${inputs[@]}" --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
 else
-    nix flake update --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
+    nix "${options[@]}" flake update --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
 fi


### PR DESCRIPTION
##### Description
Allows the user to specify options to pass to the nix command, fixes #72.

Note that the `andstor/file-reader-action@v1` was replace by `juliangruber/read-file-action@v1` because the old one used node 12, which is deprecated.

Changes were tested [here](https://github.com/xgroleau/update-flake-lock-test-template/).
##### Checklist

- [x] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
