### PR TITLE
support updating multiple flake directories simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@vX
         with:
           inputs: input1 input2 input3
-          path-to-flake-dir: 'nix/' # in this example our flake doesn't sit at the root of the repository, it sits under 'nix/flake.nix'
+          flake-dirs: 'nix/' # in this example our flake doesn't sit at the root of the repository, it sits under 'nix/flake.nix'
 ```
 
 ## Example using a different Git user

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,11 @@ inputs:
     required: false
     default: "update_flake_lock_action"
   path-to-flake-dir:
-    description: 'The path of the directory containing `flake.nix` file within your repository. Useful when `flake.nix` cannot reside at the root of your repository.'
+    description: 'Deprecated. Use flake-dirs instead. The path of the directory containing `flake.nix` file within your repository. Useful when `flake.nix` cannot reside at the root of your repository.'
+    required: false
+    default: ''
+  flake-dirs:
+    description: 'A space-separated list of directories containing `flake.nix` files within your repository. Useful when you have multiple flakes in your repository.'
     required: false
     default: ''
   pr-title:
@@ -154,6 +158,7 @@ runs:
         TARGETS: ${{ inputs.inputs }}
         COMMIT_MSG: ${{ inputs.commit-msg }}
         PATH_TO_FLAKE_DIR: ${{ inputs.path-to-flake-dir }}
+        FLAKE_DIRS: ${{ inputs.flake-dirs }}
     - name: Save PR Body as file
       uses: DamianReeves/write-file-action@v1.3
       with:

--- a/update-flake-lock.sh
+++ b/update-flake-lock.sh
@@ -1,23 +1,34 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -n "$PATH_TO_FLAKE_DIR" ]]; then
-  cd "$PATH_TO_FLAKE_DIR"
-fi
+update(){
+  if [[ -n "${TARGETS:-}" ]]; then
+      inputs=()
+      for input in $TARGETS; do
+          inputs+=("--update-input" "$input")
+      done
+      nix "${options[@]}" flake lock "${inputs[@]}" --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
+  else
+      nix "${options[@]}" flake update --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
+  fi
+}
+
 
 options=()
-if [[ -n "$NIX_OPTIONS" ]]; then
+if [[ -n "${NIX_OPTIONS:-}" ]]; then
     for option in $NIX_OPTIONS; do
         options+=("${option}")
     done
 fi
 
-if [[ -n "$TARGETS" ]]; then
-    inputs=()
-    for input in $TARGETS; do
-        inputs+=("--update-input" "$input")
-    done
-    nix "${options[@]}" flake lock "${inputs[@]}" --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
+if [[ -n "${PATH_TO_FLAKE_DIR:-}" ]]; then
+  cd "$PATH_TO_FLAKE_DIR"
+  update
+elif [[ -n "${FLAKE_DIRS:-}" ]]; then
+  for flake_dir in $FLAKE_DIRS; do
+    cd "$flake_dir"
+    update
+  done
 else
-    nix "${options[@]}" flake update --commit-lock-file --commit-lockfile-summary "$COMMIT_MSG"
+  update
 fi


### PR DESCRIPTION
##### Description

This is useful for monorepos containing multiple flakes. For example it might be desired for a nixpkgs update to happen on all sub-flakes at the same time.

Added a new option `flake-dirs` allowing to specify multiple flake directories to be updated simultaneously via a single PR.

##### Checklist

- [ ] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [x] Added or updated relevant documentation (leave unchecked if not applicable)

I did not use the test repo, but this PRs revision is already in use on the dream2nix repo