### PR TITLE
Lock third-party actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
     - name: Import bot's GPG key for signing commits
       if: ${{ inputs.sign-commits == 'true' }}
       id: import-gpg
-      uses: crazy-max/ghaction-import-gpg@v6
+      uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
       with:
         gpg_private_key: ${{ inputs.gpg-private-key }}
         fingerprint: ${{ inputs.gpg-fingerprint }}
@@ -190,7 +190,7 @@ runs:
         echo "$DELIMITER" >> $GITHUB_ENV
         echo "GIT_COMMIT_MESSAGE is: ${COMMIT_MESSAGE}"
     - name: Interpolate PR Body
-      uses: pedrolamas/handlebars-action@v2.4.0
+      uses: pedrolamas/handlebars-action@2995d7eadacbc8f2f6ab8431a01d84a5fa3b8bb4 # v2.4.0
       with:
         files: "pr_body.template"
         output-filename: "pr_body.txt"
@@ -207,7 +207,7 @@ runs:
       run: rm -f pr_body.txt pr_body.template
     - name: Create PR
       id: create-pr
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
       with:
         base: ${{ inputs.base }}
         branch: ${{ inputs.branch }}


### PR DESCRIPTION
##### Description

A caller of this action can lock this action to a specific commit. However because the action itself does not lock its dependent actions to a specific commit this opens the end-user up to possible supply-chain attacks if the dependent actions rewrite their tags.

This PR changes all third party actions to be explicitly locked.

Dependabot will still work and update these hashes for you


I also suggest installing https://github.com/ossf/scorecard in this repo. It will report about these kind of issues.

Note that you should in turn have to audit all the third party deps of the actions that your action depends on. In general this is all a bit of a mess and GitHub's security model is very meh

e.g. see https://github.com/ossf/scorecard/issues/2189

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

- [ ] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
