### PR TITLE
action.yml: expose pull-request-url from create-pr action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,6 +106,9 @@ outputs:
   pull-request-number:
     description: "The number of the opened pull request"
     value: ${{ steps.create-pr.outputs.pull-request-number }}
+  pull-request-url:
+    description: "The The URL of the opened pull request."
+    value: ${{ steps.create-pr.outputs.pull-request-url }}
   pull-request-operation:
     description: "The pull request operation performed by the action, `created`, `updated` or `closed`."
     value: ${{ steps.create-pr.outputs.pull-request-operation }}


### PR DESCRIPTION
##### Description

Pass through the `pull-request-url` output from the create-pr action

Context: users may want to notify a channel or some such with a link to the PR URL.

##### Checklist

- [ ] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
