### PR TITLE
feat: add input to allow pushing to fork

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
     description: "The branch of the PR to be created"
     required: false
     default: "update_flake_lock_action"
+  push-to-fork:
+    description:
+      "A fork of the checked out parent repository to which the pull request branch will be pushed.
+      e.g. `owner/repo-fork`.
+      The pull request will be created to merge the fork's branch into the parent's base."
+    required: false
   path-to-flake-dir:
     description: "The path of the directory containing `flake.nix` file within your repository. Useful when `flake.nix` cannot reside at the root of your repository."
     required: false
@@ -215,3 +221,4 @@ runs:
         labels: ${{ inputs.pr-labels }}
         reviewers: ${{ inputs.pr-reviewers }}
         body: ${{ steps.pr_body.outputs.content }}
+        push-to-fork: ${{ inputs.push-to-fork }}


### PR DESCRIPTION
##### Description
This commit fixes #267: it defines a new input for the GH action to
allow pushing the branch to a fork of the parent repository and creating
the PR from that fork to the parent.

##### Checklist

- [] Tested functionality against a test repository (see ["How to test changes"](../README.md#how-to-test-changes))
- [x] Added or updated relevant documentation (leave unchecked if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new optional `push-to-fork` input parameter that allows specifying a target fork repository for push operations during pull request creation workflows. This provides enhanced flexibility for fork-based contribution workflows and enables seamlessly pushing changes to alternative repositories while maintaining full pull request capabilities and functionality for automation needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->