### PR TITLE
Fix zizmor code scanning alerts in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -124,32 +124,44 @@ runs:
         git_config_global: true
         git_user_signingkey: true
         git_commit_gpgsign: true
-    - name: Set environment variables (signed commits)
-      if: ${{ inputs.sign-commits == 'true' }}
+    - name: Determine git author and committer identity
+      id: git-identity
       shell: bash
       env:
-        GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
-        GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
-        GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
-        GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
-        TARGETS: ${{ inputs.inputs }}
+        SIGN_COMMITS: ${{ inputs.sign-commits }}
+        GPG_NAME: ${{ steps.import-gpg.outputs.name }}
+        GPG_EMAIL: ${{ steps.import-gpg.outputs.email }}
+        INPUT_AUTHOR_NAME: ${{ inputs.git-author-name }}
+        INPUT_AUTHOR_EMAIL: ${{ inputs.git-author-email }}
+        INPUT_COMMITTER_NAME: ${{ inputs.git-committer-name }}
+        INPUT_COMMITTER_EMAIL: ${{ inputs.git-committer-email }}
       run: |
-        echo "GIT_AUTHOR_NAME=$GIT_AUTHOR_NAME" >> $GITHUB_ENV
-        echo "GIT_AUTHOR_EMAIL=<$GIT_AUTHOR_EMAIL>" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_NAME=$GIT_COMMITTER_NAME" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_EMAIL=<$GIT_COMMITTER_EMAIL>" >> $GITHUB_ENV
-    - name: Set environment variables (unsigned commits)
-      if: ${{ inputs.sign-commits != 'true' }}
-      shell: bash
-      run: |
-        echo "GIT_AUTHOR_NAME=${{ inputs.git-author-name }}" >> $GITHUB_ENV
-        echo "GIT_AUTHOR_EMAIL=<${{ inputs.git-author-email }}>" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_NAME=${{ inputs.git-committer-name }}" >> $GITHUB_ENV
-        echo "GIT_COMMITTER_EMAIL=<${{ inputs.git-committer-email }}>" >> $GITHUB_ENV
+        if [ "$SIGN_COMMITS" = "true" ]; then
+          AUTHOR_NAME="$GPG_NAME"
+          AUTHOR_EMAIL="$GPG_EMAIL"
+          COMMITTER_NAME="$GPG_NAME"
+          COMMITTER_EMAIL="$GPG_EMAIL"
+        else
+          AUTHOR_NAME="$INPUT_AUTHOR_NAME"
+          AUTHOR_EMAIL="$INPUT_AUTHOR_EMAIL"
+          COMMITTER_NAME="$INPUT_COMMITTER_NAME"
+          COMMITTER_EMAIL="$INPUT_COMMITTER_EMAIL"
+        fi
+        {
+          echo "author-name=$AUTHOR_NAME"
+          echo "author-email=<$AUTHOR_EMAIL>"
+          echo "committer-name=$COMMITTER_NAME"
+          echo "committer-email=<$COMMITTER_EMAIL>"
+        } >> "$GITHUB_OUTPUT"
     - name: Run update-flake-lock
       shell: bash
       run: node "$GITHUB_ACTION_PATH/dist/index.js"
       env:
+        # `nix flake update --commit-lock-file` creates the commit, and git honors these variables when doing so.
+        GIT_AUTHOR_NAME: ${{ steps.git-identity.outputs.author-name }}
+        GIT_AUTHOR_EMAIL: ${{ steps.git-identity.outputs.author-email }}
+        GIT_COMMITTER_NAME: ${{ steps.git-identity.outputs.committer-name }}
+        GIT_COMMITTER_EMAIL: ${{ steps.git-identity.outputs.committer-email }}
         # The following manually exposes all of the action inputs into INPUT_ environment variables so actionsCore.getInput works:
         # https://github.com/actions/toolkit/blob/ae38557bb0dba824cdda26ce787bd6b66cf07a83/packages/core/src/core.ts#L126
         INPUT_BASE: ${{ inputs.base }}
@@ -181,17 +193,27 @@ runs:
         path: pr_body.template
         contents: ${{ inputs.pr-body }}
       env: {}
-    - name: Set additional env variables (GIT_COMMIT_MESSAGE)
+    - name: Get commit message
+      id: commit-message
       shell: bash
       run: |
         DELIMITER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
         COMMIT_MESSAGE="$(git log --format=%b -n 1)"
-        echo "GIT_COMMIT_MESSAGE<<$DELIMITER" >> $GITHUB_ENV
-        echo "$COMMIT_MESSAGE" >> $GITHUB_ENV
-        echo "$DELIMITER" >> $GITHUB_ENV
+        {
+          echo "message<<$DELIMITER"
+          echo "$COMMIT_MESSAGE"
+          echo "$DELIMITER"
+        } >> "$GITHUB_OUTPUT"
         echo "GIT_COMMIT_MESSAGE is: ${COMMIT_MESSAGE}"
     - name: Interpolate PR Body
       uses: pedrolamas/handlebars-action@2995d7eadacbc8f2f6ab8431a01d84a5fa3b8bb4 # v2.4.0
+      env:
+        # Exposed to the `pr-body` Handlebars template as `env.GIT_*` (see README).
+        GIT_AUTHOR_NAME: ${{ steps.git-identity.outputs.author-name }}
+        GIT_AUTHOR_EMAIL: ${{ steps.git-identity.outputs.author-email }}
+        GIT_COMMITTER_NAME: ${{ steps.git-identity.outputs.committer-name }}
+        GIT_COMMITTER_EMAIL: ${{ steps.git-identity.outputs.committer-email }}
+        GIT_COMMIT_MESSAGE: ${{ steps.commit-message.outputs.message }}
       with:
         files: "pr_body.template"
         output-filename: "pr_body.txt"
@@ -213,8 +235,8 @@ runs:
         base: ${{ inputs.base }}
         branch: ${{ inputs.branch }}
         delete-branch: true
-        committer: ${{ env.GIT_COMMITTER_NAME }} ${{ env.GIT_COMMITTER_EMAIL }}
-        author: ${{ env.GIT_AUTHOR_NAME }} ${{ env.GIT_AUTHOR_EMAIL }}
+        committer: ${{ steps.git-identity.outputs.committer-name }} ${{ steps.git-identity.outputs.committer-email }}
+        author: ${{ steps.git-identity.outputs.author-name }} ${{ steps.git-identity.outputs.author-email }}
         title: ${{ inputs.pr-title }}
         token: ${{ inputs.token }}
         assignees: ${{ inputs.pr-assignees }}


### PR DESCRIPTION
## Summary

Resolves all 15 open code scanning alerts, which were zizmor findings in `action.yml`:

- **4 × `template-injection`**: `${{ inputs.git-author-name }}` and friends were interpolated directly into a `run:` script.
- **11 × `github-env`**: three steps wrote `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, and `GIT_COMMIT_MESSAGE` to `$GITHUB_ENV`.

## Changes

- Merge the two conditional "set environment variables" steps into a single `git-identity` step that selects the GPG or input-provided identity in bash. Inputs are passed via `env:` rather than interpolated, and the result is written to `$GITHUB_OUTPUT`.
- The commit-message step writes to `$GITHUB_OUTPUT` (`steps.commit-message.outputs.message`) using the same random-delimiter heredoc as before.
- Consumers reference step outputs instead of `env.*`:
  - `Run update-flake-lock` receives `GIT_AUTHOR_*`/`GIT_COMMITTER_*` via `env:`. This matters because `nix flake update --commit-lock-file` is what creates the commit, and git honors those variables.
  - The Handlebars step receives all five `GIT_*` variables via `env:`. `pedrolamas/handlebars-action` builds its template context from `{ ...process.env }`, so the documented `{{ env.GIT_COMMIT_MESSAGE }}` etc. in `pr-body` templates keep working unchanged.
  - `Create PR`'s `author`/`committer` use the step outputs.
- Drop an unused `TARGETS: ${{ inputs.inputs }}` env var from the old signed step.

## Behavior note

Previously the `GIT_*` variables leaked via `GITHUB_ENV` into any steps *after* `update-flake-lock` in a caller's workflow. That was never documented (the README only lists them as `pr-body` template variables), so this PR does not preserve it. If we know of users relying on it, explicit action outputs would be the right replacement.

## Verification

- `zizmor --config .github/zizmor.yml action.yml .github/workflows` → no findings (was 15 high). The pedantic persona shows only one pre-existing `superfluous-actions` info.
- YAML parses; `prettier --check action.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved commit identity handling for signed commits and configured author details.
  - Commit and pull request updates now consistently use the resolved author and committer information.
  - Improved transfer of multiline commit messages during workflow execution.
  - Pull request creation now reflects the selected commit identity more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->